### PR TITLE
Fix for incorrect character coordinates when scrolled

### DIFF
--- a/src/cm_adapter.ts
+++ b/src/cm_adapter.ts
@@ -553,7 +553,7 @@ export class CodeMirror {
     var rect = this.cm6.contentDOM.getBoundingClientRect();
     var offset = indexFromPos(this.cm6.state.doc, pos)
     var coords = this.cm6.coordsAtPos(offset)
-    var d = this.cm6.scrollDOM.scrollTop - rect.top
+    var d = -rect.top
     return { left: (coords?.left || 0) - rect.left, top: (coords?.top || 0) + d, bottom: (coords?.bottom || 0) + d }
   };
   coordsChar(coords: { left: number, top: number }, mode: "div" | "local") {


### PR DESCRIPTION
See https://github.com/replit/codemirror-vim/pull/24.