### PR TITLE
Really use capturing phase

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,10 +31,11 @@ type EditorViewExtended = EditorView&{cm:CodeMirror}
 
 const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
   private dom: HTMLElement;
+  private keydownHandler;
   public view: EditorViewExtended;
   public cm: CodeMirror;
   public status = ""
-  blockCursor: BlockCursorPlugin 
+  blockCursor: BlockCursorPlugin
   constructor(view: EditorView) {
     this.view = view as EditorViewExtended
     const cm = this.cm = new CodeMirror(view);
@@ -51,6 +52,7 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
       this.blockCursor.scheduleRedraw();
       this.updateStatus()
     });
+
     this.cm.on('vim-mode-change', (e: any) => {
       cm.state.vim.mode = e.mode;
       if (e.subMode) {
@@ -61,7 +63,6 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
       this.updateClass()
       this.updateStatus()
     });
-    
 
     this.cm.on("dialog", () => {
       if (this.cm.state.statusbar) {
@@ -75,6 +76,52 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
 
     this.dom = document.createElement("span");
     this.dom.style.cssText = "position: absolute; right: 10px; top: 1px";
+
+    // Add a capturing event handler to ensure CodeMirror hasn't had a chance to prevent the default behaviour
+    this.keydownHandler = (e: KeyboardEvent) => {
+      if (e.target === view.contentDOM) {
+        this.handleKeydownEvent(e)
+      }
+    }
+
+    // The event handler needs to be attached to the document in order to catch it in the capturing phase
+    view.contentDOM.ownerDocument.addEventListener('keydown', this.keydownHandler, { capture: true })
+  }
+
+  handleKeydownEvent(e: KeyboardEvent) {
+    const key = CodeMirror.vimKey(e)
+    const cm = this.cm
+    if (!key) return
+
+    // clear search highlight
+    let vim = cm.state.vim
+    if (key == "<Esc>"
+        && !vim.insertMode && !vim.visualMode
+        && this.query/* && !cm.inMultiSelectMode*/
+    ) {
+      cm.removeOverlay(null);
+    }
+
+    cm.state.vim.status = (cm.state.vim.status|| "") + key
+    let result = Vim.multiSelectHandleKey(cm, key, "user");
+
+    // insert mode
+    if (!result && cm.state.vim.insertMode && cm.state.overwrite) {
+      if (e.key && e.key.length == 1 && !/\n/.test(e.key)) {
+        result = true;
+        cm.overWriteSelection(e.key)
+      } else if (e.key == "Backspace") {
+        result = true;
+        CodeMirror.commands.cursorCharLeft(cm)
+      }
+    }
+    if (result) {
+      e.preventDefault()
+      e.stopPropagation()
+      this.blockCursor.scheduleRedraw();
+    }
+
+    this.updateStatus()
   }
 
   update(update: ViewUpdate) {
@@ -82,16 +129,16 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
       this.cm.onChange(update)
       if (this.query)
         this.highlight(this.query)
-    } 
+    }
     if (update.selectionSet) {
       this.cm.onSelectionChange()
-    } 
+    }
     if (update.viewportChanged) {
       // scroll
     }
     if (this.cm.curOp && !this.cm.curOp.isVimOp) {
       this.cm.onBeforeEndOperation();
-    } 
+    }
     if (update.transactions) {
       for (let tr of update.transactions)
       for (let effect of tr.effects) {
@@ -113,7 +160,7 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
     const state = this.cm.state;
     if (!state.vim || (state.vim.insertMode && !state.overwrite))
       this.view.scrollDOM.classList.remove("cm-vimMode")
-    else 
+    else
       this.view.scrollDOM.classList.add("cm-vimMode")
   }
   updateStatus() {
@@ -139,11 +186,13 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
     this.updateClass()
     this.blockCursor.destroy();
     delete (this.view as any).cm;
+    this.view.contentDOM.ownerDocument.removeEventListener('keydown', this.keydownHandler, { capture: true })
+    this.keydownHandler = () => {}
   }
 
   highlight(query: any) {
     this.query = query;
-    if (!query) 
+    if (!query)
       return this.decorations = Decoration.none
     let {view} = this
     let builder = new RangeSetBuilder<Decoration>()
@@ -160,46 +209,6 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
   decorations = Decoration.none
 
 }, {
-  eventHandlers: {
-    keydown: function(e: KeyboardEvent, view: EditorView) {
-      const key = CodeMirror.vimKey(e)
-      const cm = this.cm
-      if (!key) return
-      
-      // clear search highlight
-      let vim = cm.state.vim
-      if (key == "<Esc>"
-       && !vim.insertMode && !vim.visualMode 
-       && this.query/* && !cm.inMultiSelectMode*/
-      ) {
-        cm.removeOverlay(null);
-      }
-
-      cm.state.vim.status = (cm.state.vim.status|| "") + key
-      let result = Vim.multiSelectHandleKey(cm, key, "user");
-
-      // insert mode
-      if (!result && cm.state.vim.insertMode && cm.state.overwrite) {
-        if (e.key && e.key.length == 1 && !/\n/.test(e.key)) {
-          result = true;
-          cm.overWriteSelection(e.key)
-        } else if (e.key == "Backspace") {
-          result = true;
-          CodeMirror.commands.cursorCharLeft(cm)
-        }
-      }
-      if (result) {
-        e.preventDefault()
-        e.stopPropagation()
-        this.blockCursor.scheduleRedraw();
-      } 
-
-      this.updateStatus()
-
-      return !!result;
-    }
-  },
-  
   decorations: v => v.decorations
 })
 


### PR DESCRIPTION
Turns out I didn't properly understand about the phases of a DOM event.

What happens is that the event travels from top down first; until it reaches the target, it's in capturing phase. When it reaches the target (CM6's `contentDOM` in this case), it's neither in capturing or bubbling phase, it's just at the target, which is the bit I had a false assumption about. It then goes back up to the top in the bubbling phase. The mistake I made originally was thinking that when it reached the target, it would fire once there in capturing phase and once in bubbling, which is not what happens.

The result was that the `keydown` event handler I added was not guaranteed to fire before CM6's handler. This PR fixes this by putting the handler on `document` instead and check that the event target is `contentDOM`. 