### PR TITLE
Call leaveVimMode on plugin unload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ const vimPlugin = ViewPlugin.fromClass(
     }
 
     destroy() {
-      this.cm.state.vim = null;
+      Vim.leaveVimMode(this.cm);
       this.updateClass();
       this.blockCursor.destroy();
       delete (this.view as any).cm;

--- a/src/vim.js
+++ b/src/vim.js
@@ -284,6 +284,7 @@ export function initVim(CodeMirror) {
       cm.off('cursorActivity', onCursorActivity);
       CodeMirror.off(cm.getInputField(), 'paste', getOnPasteFn(cm));
       cm.state.vim = null;
+      vimGlobalState.jumpList = createCircularJumpList();
       if (highlightTimeout) clearTimeout(highlightTimeout);
     }
 

--- a/src/vim.js
+++ b/src/vim.js
@@ -711,6 +711,8 @@ export function initVim(CodeMirror) {
     var lastInsertModeKeyTimer;
     var vimApi = {
       enterVimMode: enterVimMode,
+      leaveVimMode: leaveVimMode,
+
       buildKeyMap: function() {
         // TODO: Convert keymap into dictionary format for fast lookup.
       },


### PR DESCRIPTION
This should make sure the `paste` event listener gets removed when the plugin is unloaded.