### PR TITLE
Reset global jumpList on unload

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -299,6 +299,7 @@ export function initVim(CodeMirror) {
       cm.off('cursorActivity', onCursorActivity);
       CodeMirror.off(cm.getInputField(), 'paste', getOnPasteFn(cm));
       cm.state.vim = null;
+      vimGlobalState.jumpList = createCircularJumpList();
       if (highlightTimeout) clearTimeout(highlightTimeout);
     }
 


### PR DESCRIPTION
Repeating from #67:

This PR resets the `jumpList` that contains document references on unload. This fixes an issue where the extension would attempt to access out-of-range document data when switching between files.

To replicate bug in dev environment:
1. Type (insert mode) `module` on first line of the Javascript editor
2. Tick "html"
3. Type (normal mode) `/module`
4. Press `n` until last match is highlighted
5. Until "html"
6. Press `n`
