### PR TITLE
fix arrow navigation

### DIFF
--- a/src/cm_adapter.ts
+++ b/src/cm_adapter.ts
@@ -315,18 +315,19 @@ export class CodeMirror {
   setSelections(p: CM5Range[], primIndex?: number) {
     var doc = this.cm6.state.doc
     var ranges = p.map(x => {
-      return EditorSelection.range(indexFromPos(doc, x.anchor), indexFromPos(doc, x.head))
+      var head = indexFromPos(doc, x.head)
+      var anchor = indexFromPos(doc, x.anchor)
+      // workaround for codemirror bug, see https://github.com/replit/codemirror-vim/issues/169
+      if (head == anchor)
+        return EditorSelection.cursor(head, 1)
+      return EditorSelection.range(anchor, head)
     })
     this.cm6.dispatch({
       selection: EditorSelection.create(ranges, primIndex)
     })
   };
   setSelection(anchor: Pos, head: Pos, options?: any) {
-    var doc = this.cm6.state.doc
-    var ranges = [EditorSelection.range(indexFromPos(doc, anchor), indexFromPos(doc, head))]
-    this.cm6.dispatch({
-      selection: EditorSelection.create(ranges, 0)
-    })
+    this.setSelections([{anchor, head}], 0);
     if (options && options.origin == '*mouse') {
       this.onBeforeEndOperation();
     }
@@ -582,7 +583,7 @@ export class CodeMirror {
     let pixels = unit == 'page' ? cm6.dom.clientHeight : 0;
 
     const startOffset = indexFromPos(doc, start);
-    let range = EditorSelection.range(startOffset, startOffset, goalColumn);
+    let range = EditorSelection.cursor(startOffset, 1, undefined, goalColumn);
     let count = Math.round(Math.abs(amount))
     for (let i = 0; i < count; i++) {
       if (unit == 'page') {


### PR DESCRIPTION
# Why
fixes an issue where 'gk' command will skip 2 lines when at the start of a word wrapped line:
https://github.com/overleaf/internal/issues/19714


# What changed

copying the patch here: https://github.com/replit/codemirror-vim/pull/170
spawned form this issue (same as ours) https://github.com/replit/codemirror-vim/issues/165

from the issue, the change fixes a bug in [EditorSelection.range](https://codemirror.net/docs/ref/#state.EditorSelection%5Erange) which creates a cursor that is displayed as a range with assoc=1, but behaves as one with assoc=-1

# Test plan
tested by manually applying the same changes in the node_modules of web, and re-created the repro steps of https://github.com/overleaf/internal/issues/19714
